### PR TITLE
Force method names to string.

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -1,6 +1,7 @@
 import json
 import inspect
 from django.contrib.admindocs.views import simplify_regex
+from django.utils.encoding import force_str
 
 
 class ApiEndpoint(object):
@@ -25,7 +26,7 @@ class ApiEndpoint(object):
         return simplify_regex(self.pattern.regex.pattern)
 
     def __get_allowed_methods__(self):
-        return [m.upper() for m in self.callback.cls.http_method_names if hasattr(self.callback.cls, m)]
+        return [force_str(m).upper() for m in self.callback.cls.http_method_names if hasattr(self.callback.cls, m)]
 
     def __get_docstring__(self):
         return inspect.getdoc(self.callback)


### PR DESCRIPTION
The allowed methods list is printed directly into the template. In my case this results in unicode representation of the method names: "[u&#39;GET&#39;, u&#39;OPTIONS&#39;]"

Forcing the names in the list to a string should solve this problem.