### PR TITLE
Use Django's module loading rather than __import__

### DIFF
--- a/rest_framework_docs/api_docs.py
+++ b/rest_framework_docs/api_docs.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
+from django.utils.module_loading import import_string
 from rest_framework.views import APIView
 from rest_framework_docs.api_endpoint import ApiEndpoint
 
@@ -8,7 +9,7 @@ class ApiDocumentation(object):
 
     def __init__(self):
         self.endpoints = []
-        root_urlconf = __import__(settings.ROOT_URLCONF)
+        root_urlconf = import_string(settings.ROOT_URLCONF)
         if hasattr(root_urlconf, 'urls'):
             self.get_all_view_names(root_urlconf.urls.urlpatterns)
         else:


### PR DESCRIPTION
\_\_import\_\_ doesn't deal well with dotted paths, in my instance my root url conf is in a few levels `ROOT_URLCONF = "appname.config.urls"`. unfortunately, for \_\_import\_\_ this means that just `appname` is imported, but `config.urls` is loaded and no other modules in between are usable. Switching to Django's `import_string` method allows importing the final module in the path string, in my case the equivalent would be `from appname.config import urls`.