### PR TITLE
Fix middle slash removed by replace

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -11,7 +11,7 @@ class ApiEndpoint(object):
         self.callback = pattern.callback
         # self.name = pattern.name
         self.docstring = self.__get_docstring__()
-        self.name_parent = simplify_regex(parent_pattern.regex.pattern).replace('/', '') if parent_pattern else None
+        self.name_parent = simplify_regex(parent_pattern.regex.pattern).strip('/') if parent_pattern else None
         self.path = self.__get_path__(parent_pattern)
         self.allowed_methods = self.__get_allowed_methods__()
         # self.view_name = pattern.callback.__name__


### PR DESCRIPTION
This pull request fixes issue #54 by using the method strip('/') to remove leading and trailing slashes from parent URL instead of the method replace('/', '') which also removed slashes in-between.