### PR TITLE
fix docs link references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Document Web APIs made with Django Rest Framework. [View Demo](http://demo.drfdo
 
 ### Documentation - Table of contents
 
-  - [Installation](http://drfdocs.com/docs/installation/)
-  - [Settings](http://drfdocs.com/docs/settings/)
-  - [Extending the template](http://drfdocs.com/docs/templates/)
-  - [Live API Endpoints](http://drfdocs.com/docs/live-api/)
-  - [Contributing & Development](http://drfdocs.com/docs/contributing/)
-  - [Changelog](http://drfdocs.com/docs/changelog/)
+  - [Installation](http://drfdocs.com/installation/)
+  - [Settings](http://drfdocs.com/settings/)
+  - [Extending the template](http://drfdocs.com/templates/)
+  - [Live API Endpoints](http://drfdocs.com/live-api/)
+  - [Contributing & Development](http://drfdocs.com/contributing/)
+  - [Changelog](http://drfdocs.com/changelog/)
 
 
 ### Development & Demo Project
@@ -31,7 +31,7 @@ If you are looking to develop this package with one of your own django projects:
 If you want to use the demo app to work on this package:
 Included in this repo you can find the demo project(at `/demo`). It is a project with *Django* & *Django Rest Framework* that will allow you to work with this project. For more information on how you can set it up please check the [README.md](demo/README.md) of the demo project.
 
-For more information visit [the docs](http://drfdocs.com/docs/contributing/).
+For more information visit [the docs](http://drfdocs.com/contributing/).
 
 ### Installation
 
@@ -55,7 +55,7 @@ Finally include the `rest_framework_docs` urls in your `urls.py`:
 
 
 ### Settings
-You can find detailed information about the package's settings at [the docs](http://drfdocs.com/docs/settings/).
+You can find detailed information about the package's settings at [the docs](http://drfdocs.com/settings/).
 
     REST_FRAMEWORK_DOCS = {
         'HIDE_DOCS': True  # Default: False


### PR DESCRIPTION
All http://drfdocs.com/docs/* now are pointing to  http://drfdocs.com/