### PR TITLE
Minor documentation update

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,7 +12,7 @@ To set DRF docs' settings just include the dictionary below in Django's `setting
 
 ### Settings Description
 
-##### HIDDEN
+##### HIDE_DOCS
 You can use hidden to prevent your docs from showing up in different environments (ie. Show in development, hide in production). To do so you can use environment variables.
 
     REST_FRAMEWORK_DOCS = {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -16,10 +16,10 @@ To set DRF docs' settings just include the dictionary below in Django's `setting
 You can use hidden to prevent your docs from showing up in different environments (ie. Show in development, hide in production). To do so you can use environment variables.
 
     REST_FRAMEWORK_DOCS = {
-        'HIDE_DOCS': os.environ.get('SHOW_DRFDOCS', False)
+        'HIDE_DOCS': os.environ.get('HIDE_DRFDOCS', False)
     }
 
-Then set the value of the environment variable `SHOW_DRFDOCS` for each environment (ie. Use `.env` files)
+Then set the value of the environment variable `HIDE_DRFDOCS` for each environment (ie. Use `.env` files)
 
 ### List of Settings
 


### PR DESCRIPTION
We shouldn't propose people to use incorrectly named env variables:
previously:
if "SHOW_DRFDOCS" is True - docs are hidden
now: correct naming of variables.