### PR TITLE
Added reStructuredText support for endpoint docstring documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework==3.3.2
 coverage==4.0.3
 flake8==2.5.1
 mkdocs==0.15.3
+django-markwhat==1.5

--- a/rest_framework_docs/templates/rest_framework_docs/home.html
+++ b/rest_framework_docs/templates/rest_framework_docs/home.html
@@ -1,5 +1,7 @@
 {% extends "rest_framework_docs/docs.html" %}
 
+{% load markup %}
+
 {% block apps_menu %}
 {% regroup endpoints by name_parent as endpoints_grouped %}
 <li class="dropdown">
@@ -56,7 +58,7 @@
         <div id="{{ endpoint.path|slugify }}" class="panel-collapse collapse" role="tabpanel">
           <div class="panel-body">
             {% if endpoint.docstring %}
-            <p class="lead">{{ endpoint.docstring }}</p>
+            <p class="lead">{{ endpoint.docstring|rst }}</p>
             {% endif %}
 
             {% if endpoint.errors %}

--- a/rest_framework_docs/templatetags/markup.py
+++ b/rest_framework_docs/templatetags/markup.py
@@ -1,0 +1,14 @@
+"""
+Defining a custom template tag as a wrapper around the restructuredtext template tag provided by the
+django-markwhat library. This prevents the need for users to also install django-markwhat into their
+INSTALLED_APPS.
+"""
+from django import template
+from django_markwhat.templatetags.markup import restructuredtext
+
+register = template.Library()
+
+
+@register.filter(is_safe=True)
+def rst(value):
+    return restructuredtext(value)


### PR DESCRIPTION
I recently started using drfdocs and wanted to add some documentation onto each view I have. Some extra documentation I have needed to be formatted (line breaks etc) and was longer than a single line. 

This simple change allows reStructuredText to be added to a DRF View docstring, meaning users can add structured documentation that can be viewed when clicking on each API on the docs page.