### PR TITLE
Bugfix: an endpoint without a parent contaminated with its predecessor's parent.

### DIFF
--- a/rest_framework_docs/api_docs.py
+++ b/rest_framework_docs/api_docs.py
@@ -24,8 +24,8 @@ class ApiDocumentation(object):
     def get_all_view_names(self, urlpatterns, parent_pattern=None):
         for pattern in urlpatterns:
             if isinstance(pattern, RegexURLResolver):
-                parent_pattern = None if pattern._regex == "^" else pattern
-                self.get_all_view_names(urlpatterns=pattern.url_patterns, parent_pattern=parent_pattern)
+                new_parent_pattern = None if pattern._regex == "^" else pattern
+                self.get_all_view_names(urlpatterns=pattern.url_patterns, parent_pattern=new_parent_pattern)
             elif isinstance(pattern, RegexURLPattern) and self._is_drf_view(pattern) and not self._is_format_endpoint(pattern):
                 api_endpoint = ApiEndpoint(pattern, parent_pattern, self.drf_router)
                 self.endpoints.append(api_endpoint)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -49,6 +49,8 @@ class DRFDocsViewTests(TestCase):
         # The view "OrganisationErroredView" (organisations/(?P<slug>[\w-]+)/errored/) should contain an error.
         self.assertEqual(str(response.context["endpoints"][9].errors), "'test_value'")
 
+        self.assertEqual(response.context["endpoints"][14].path, "/another-login/")
+
     def test_index_search_with_endpoints(self):
         response = self.client.get("%s?search=reset-password" % reverse("drfdocs"))
 
@@ -75,8 +77,8 @@ class DRFDocsViewTests(TestCase):
 
         self.assertEqual(response.context["endpoints"][10].path, '/organisations/<slug>/')
         self.assertEqual(response.context['endpoints'][6].fields[2]['to_many_relation'], True)
-        self.assertEqual(response.context["endpoints"][11].path, '/organisation-model-viewsets/')
-        self.assertEqual(response.context["endpoints"][12].path, '/organisation-model-viewsets/<pk>/')
+        self.assertEqual(response.context["endpoints"][11].path, '/router/organisation-model-viewsets/')
+        self.assertEqual(response.context["endpoints"][12].path, '/router/organisation-model-viewsets/<pk>/')
         self.assertEqual(response.context["endpoints"][11].allowed_methods, ['GET', 'POST', 'OPTIONS'])
         self.assertEqual(response.context["endpoints"][12].allowed_methods, ['GET', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'])
         self.assertEqual(response.context["endpoints"][13].allowed_methods, ['POST', 'OPTIONS'])

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     # API
     url(r'^accounts/', view=include(accounts_urls, namespace='accounts')),
     url(r'^organisations/', view=include(organisations_urls, namespace='organisations')),
-    url(r'^', include(router.urls)),
+    url(r'^router/', include(router.urls)),
 
     # Endpoints without parents/namespaces
     url(r'^another-login/$', views.LoginView.as_view(), name="login"),


### PR DESCRIPTION
The `/another-login/` endpoint only worked correctly, because it was preceded by a pattern with an empty parent. Had the previous parent been not empty (as in the amended test), the last pattern would've been rendered as `/router/another-login/`, because of the `parent_pattern` variable reuse in the fixed loop.