### PR TITLE
Support for permission classes specified using rest_condition

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -71,7 +71,10 @@ class ApiEndpoint(object):
 
     def __get_permissions_class__(self):
         for perm_class in self.pattern.callback.cls.permission_classes:
-            return perm_class.__name__
+            try:
+                return perm_class.__name__
+            except:
+                return perm_class.__class__.__name__
 
     def __get_serializer__(self):
         try:


### PR DESCRIPTION
Basically the idea of this change is that if the permission classes is specified not by adding the permissions classes in the tuple but by using a [third party resource](http://www.django-rest-framework.org/api-guide/permissions/#rest-condition) providing us with conditional usage of permissions, the __get_permissions_class__ fails, because this conditional permission creates an object for the condition. 

For eg. if we have a view specified as.

```
from rest_condition import OR

class ABCView(ModelViewSet):
    permission_classes = (OR(Permission1, Permission2),)
    """Some other stuff"""
```

The error in this case comes out to be Condition object has no attribute __name__, which makes sense.

Kindly look into the issue if this is mergeable.

Maybe there is a better approach to do this.... 

Thanks!
Arpit