### PR TITLE
Add api router setting

### DIFF
--- a/rest_framework_docs/settings.py
+++ b/rest_framework_docs/settings.py
@@ -5,7 +5,8 @@ class DRFSettings(object):
 
     def __init__(self):
         self.drf_settings = {
-            "HIDE_DOCS": self.get_setting("HIDE_DOCS") or False
+            "HIDE_DOCS": self.get_setting("HIDE_DOCS") or False,
+            "API_ROUTER": self.get_setting("API_ROUTER")
         }
 
     def get_setting(self, name):

--- a/rest_framework_docs/views.py
+++ b/rest_framework_docs/views.py
@@ -15,7 +15,7 @@ class DRFDocsView(TemplateView):
             raise Http404("Django Rest Framework Docs are hidden. Check your settings.")
 
         context = super(DRFDocsView, self).get_context_data(**kwargs)
-        docs = ApiDocumentation(drf_router=self.drf_router)
+        docs = ApiDocumentation(drf_router=settings['API_ROUTER'])
         endpoints = docs.get_endpoints()
 
         query = self.request.GET.get("search", "")


### PR DESCRIPTION
Allows use custom router, for example when you use an autodiscover.