### PR TITLE
Fields in table representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Finally include the `rest_framework_docs` urls in your `urls.py`:
 You can find detailed information about the package's settings at [the docs](http://drfdocs.com/settings/).
 
     REST_FRAMEWORK_DOCS = {
-        'HIDE_DOCS': True  # Default: False
+        'HIDE_DOCS': True,  # Default: False
+        'DESC_TABLE': True # Default: False
     }
 
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ You can use hidden to prevent your docs from showing up in different environment
     }
 
 ##### DESC_TABLE
-You can use Table representation to make your fields list in the documentation clear. So We can change representation by adding single line inside the `REST_FRAMEWORK_DOCS` in `setting.py`.
+You can use Table representation to make your fields list in the documentation clear. So We can change representation by adding single line inside the `REST_FRAMEWORK_DOCS` in `settings.py`.
 
     'DESC_TABLE': os.environ.get('DESCRIBE_TABLE', False)
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -19,11 +19,17 @@ You can use hidden to prevent your docs from showing up in different environment
         'HIDE_DOCS': os.environ.get('HIDE_DRFDOCS', False)
     }
 
+##### DESC_TABLE
+You can use Table representation to make your fields list in the documentation clear. So We can change representation by adding single line inside the `REST_FRAMEWORK_DOCS` in `setting.py`.
+
+    'DESC_TABLE': os.environ.get('DESCRIBE_TABLE', False)
+
+
 Then set the value of the environment variable `HIDE_DRFDOCS` for each environment (ie. Use `.env` files)
 
 ### List of Settings
 
-| Setting | Type    | Options         | Default |
-|---------|---------|-----------------|---------|
-|HIDE_DOCS| Boolean | `True`, `False` | `False` |
-|         |         |                 |         |
+| Setting  | Type    | Options         | Default |
+|----------|---------|-----------------|---------|
+|HIDE_DOCS | Boolean | `True`, `False` | `False` |
+|DESC_TABLE| Boolean | `True`, `False` | `False` |

--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -123,7 +123,7 @@ class ApiEndpoint(object):
                     "sub_fields": sub_fields,
                     "required": field.required,
                     "to_many_relation": to_many_relation,
-                    "max_length": (field.__dict__.get('max_length', '-') if field.__dict__.get('max_length', '-') != None else '-')
+                    "max_length": (field.__dict__.get('max_length', '-') if field.__dict__.get('max_length', '-') is not None else '-')
                 })
             # FIXME:
             # Show more attibutes of `field`?

--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -122,7 +122,8 @@ class ApiEndpoint(object):
                     "type": str(field.__class__.__name__),
                     "sub_fields": sub_fields,
                     "required": field.required,
-                    "to_many_relation": to_many_relation
+                    "to_many_relation": to_many_relation,
+                    "max_length": (field.__dict__.get('max_length', '-') if field.__dict__.get('max_length', '-') != None else '-')
                 })
             # FIXME:
             # Show more attibutes of `field`?

--- a/rest_framework_docs/settings.py
+++ b/rest_framework_docs/settings.py
@@ -5,7 +5,8 @@ class DRFSettings(object):
 
     def __init__(self):
         self.drf_settings = {
-            "HIDE_DOCS": self.get_setting("HIDE_DOCS") or False
+            "HIDE_DOCS": self.get_setting("HIDE_DOCS") or False,
+            "DESC_TABLE": self.get_setting("DESC_TABLE") or False
         }
 
     def get_setting(self, name):

--- a/rest_framework_docs/templates/rest_framework_docs/home.html
+++ b/rest_framework_docs/templates/rest_framework_docs/home.html
@@ -1,3 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+}
+
+tr:nth-child(even) {
+    background-color: #ECF0F1;
+}
+</style>
+</head>
 {% extends "rest_framework_docs/docs.html" %}
 {% load drfdocs_filters %}
 
@@ -65,8 +86,29 @@
             {% endif %}
 
             {% if endpoint.fields %}
+              {% if desc_table %}
+                <p class="fields-desc">Fields details:</p>
+                <table>
+                  <tr>
+                    <th> Field Name </th>
+                    <th> Field Type </th>
+                    <th> Max Length </th>
+                    <th> Is Required </th>
+                  </tr>
+                  {% for field in endpoint.fields %}
+                    <tr>
+                      <td> {{ field.name }} </td>
+                      <td> {{ field.type }} </td>
+                      <td> {{ field.max_length }} </td>
+                      <td> {{ field.required }} </td>
+                    </tr>
+                  {% endfor %}
+                </table>
+              {% else %}
+
             <p class="fields-desc">Fields:</p>
               {%include "rest_framework_docs/components/fields_list.html" with fields=endpoint.fields %}
+              {% endif %}
             {% elif not endpoint.errors %}
             <p>No fields.</p>
             {% endif %}
@@ -99,3 +141,4 @@
   </div>
 
 {% endblock %}
+</html>

--- a/rest_framework_docs/views.py
+++ b/rest_framework_docs/views.py
@@ -24,4 +24,5 @@ class DRFDocsView(TemplateView):
 
         context['query'] = query
         context['endpoints'] = endpoints
+        context['desc_table'] = settings['DESC_TABLE']
         return context


### PR DESCRIPTION
Here I have added the feature of fields with the table representation. So you can use **Table** representation to make your fields list in the documentation clear. So We can change representation by adding single line inside the `REST_FRAMEWORK_DOCS` in `settings.py`. And also show `max_length` field in table representation. Sample output I attached here.
![fields_table_repr](https://user-images.githubusercontent.com/9946971/28448785-6e9bb5be-6df8-11e7-89d5-68e84a4d8611.png)

