### PR TITLE
docs: Fix simple typo, attibutes -> attributes

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -125,7 +125,7 @@ class ApiEndpoint(object):
                     "to_many_relation": to_many_relation
                 })
             # FIXME:
-            # Show more attibutes of `field`?
+            # Show more attributes of `field`?
 
         return fields
 


### PR DESCRIPTION
There is a small typo in rest_framework_docs/api_endpoint.py.

Should read `attributes` rather than `attibutes`.

